### PR TITLE
Added APIs for bootstrapping

### DIFF
--- a/codebuild/ci_build.sh
+++ b/codebuild/ci_build.sh
@@ -4,4 +4,6 @@
 
 cmake -Bbuild -GNinja . -DLATTICPP_BUILD_EXAMPLES=ON
 # build all targets
-ninja -Cbuild run_gobindingtest
+ninja -Cbuild
+ninja -Cbuild run_bootstrapexample
+ninja -Cbuild run_sigmoidexample

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_executable(gobindingtest ${CMAKE_CURRENT_SOURCE_DIR}/sigmoid.cpp)
-target_link_libraries(gobindingtest aws-lattigo-cpp)
+add_executable(sigmoidexample ${CMAKE_CURRENT_SOURCE_DIR}/sigmoid.cpp)
+target_link_libraries(sigmoidexample aws-lattigo-cpp)
 add_custom_target(
-  run_gobindingtest
-  COMMAND bin/${CMAKE_BUILD_TYPE}/gobindingtest
+  run_sigmoidexample
+  COMMAND bin/${CMAKE_BUILD_TYPE}/sigmoidexample
   WORKING_DIRECTORY ${LATTICPP_ROOT_DIR}
-  DEPENDS gobindingtest)
+  DEPENDS sigmoidexample)
+
+add_executable(bootstrapexample ${CMAKE_CURRENT_SOURCE_DIR}/bootstrapping.cpp)
+target_link_libraries(bootstrapexample aws-lattigo-cpp)
+add_custom_target(
+  run_bootstrapexample
+  COMMAND bin/${CMAKE_BUILD_TYPE}/bootstrapexample
+  WORKING_DIRECTORY ${LATTICPP_ROOT_DIR}
+  DEPENDS bootstrapexample)

--- a/examples/bootstrapping.cpp
+++ b/examples/bootstrapping.cpp
@@ -1,0 +1,80 @@
+
+#include "latticpp/latticpp.h"
+
+#include <cmath>
+#include <iomanip>
+#include <vector>
+
+using namespace std;
+using namespace latticpp;
+
+// generate a random vector of the given dimension, where each value is in the range [-maxNorm, maxNorm].
+vector<double> randomVector(int dim, double maxNorm) {
+    vector<double> x(dim);
+
+    for (int i = 0; i < dim; i++) {
+        // generate a random double between -maxNorm and maxNorm
+        double a = -maxNorm + ((static_cast<double>(random())) / (static_cast<double>(RAND_MAX))) * (2 * maxNorm);
+        x[i] = a;
+    }
+    return x;
+}
+
+vector<double> printDebug(const Parameters &params, const Ciphertext &ciphertext, vector<double> &expectedPT, const Decryptor &decryptor, const Encoder encoder) {
+
+    vector<double> actualPT = decode(encoder, decryptNew(decryptor, ciphertext), logSlots(params));
+
+    cout << "Level: " << level(ciphertext) << " (logQ = " << logQLvl(params, level(ciphertext)) << ")" << endl;
+    cout << "Scale: 2^" << log2(scale(ciphertext)) << endl;
+
+    cout << "Actual Result: " << setprecision(3) << actualPT[0] << " " << actualPT[1] << " " << actualPT[2] << " " << actualPT[3] << endl;
+    cout << "Expected Result: " << setprecision(3) << expectedPT[0] << " " << expectedPT[1] << " " << expectedPT[2] << " " << expectedPT[3] << endl;
+
+    string precStats = precisionStats(params, expectedPT, actualPT);
+
+    cout << precStats << endl;
+
+    return actualPT;
+}
+
+int main() {
+
+    Parameters params = getParams(BootstrapParams0);
+    BootstrappingParameters btpParams = getBootstrappingParams(BootstrapParams_Set2);
+
+    cout << "CKKS parameters: logN = " << logN(params) << ", logSlots = " << logSlots(params)
+         << ", h = " << bootstrap_h(btpParams) << ", logQP = " << logQP(params)
+         << ", levels = " << qiCount(params) << ", scale = 2^" << log2(scale(params))
+         << ", sigma = " << sigma(params) << endl;
+
+    KeyGenerator kgen = newKeyGenerator(params);
+    struct KeyPairHandle kp = genKeyPair(kgen);
+
+    Encoder encoder = newEncoder(params);
+    Decryptor decryptor = newDecryptor(params, kp.sk);
+    Encryptor encryptor = newEncryptorFromPk(params, kp.pk);
+
+    cout << "Generating bootstrapping keys..." << endl;
+    BootstrappingKey btpKey = genBootstrappingKey(kgen, logSlots(params), btpParams, kp.sk);
+    Bootstrapper btp = newBootstrapper(params, btpParams, btpKey);
+    cout << "Done" << endl;
+
+    uint64_t num_slots = numSlots(params);
+    vector<double> values = randomVector(num_slots, 8);
+
+    Plaintext plaintext = encodeNTTAtLvlNew(params, encoder, values, maxLevel(params), scale(params));
+
+    Ciphertext ciphertext1 = encryptNew(encryptor, plaintext);
+
+    cout << "Precision of values vs. ciphertext" << endl;
+    vector<double> valuesTest1 = printDebug(params, ciphertext1, values, decryptor, encoder);
+
+    cout << "Bootstrapping..." << endl;
+    Ciphertext ciphertext2 = bootstrap(btp, ciphertext1);
+    cout << "Done" << endl;
+
+    cout << "Precision of ciphertext vs. Bootstrapp(ciphertext)" << endl;
+    printDebug(params, ciphertext2, valuesTest1, decryptor, encoder);
+
+    return 0;
+}

--- a/examples/bootstrapping.cpp
+++ b/examples/bootstrapping.cpp
@@ -3,6 +3,7 @@
 
 #include <cmath>
 #include <iomanip>
+#include <random>
 #include <vector>
 
 using namespace std;
@@ -11,11 +12,13 @@ using namespace latticpp;
 // generate a random vector of the given dimension, where each value is in the range [-maxNorm, maxNorm].
 vector<double> randomVector(int dim, double maxNorm) {
     vector<double> x(dim);
+    random_device r;
+    uniform_real_distribution<double> unif(-maxNorm, maxNorm);
+    default_random_engine re(r());
 
     for (int i = 0; i < dim; i++) {
         // generate a random double between -maxNorm and maxNorm
-        double a = -maxNorm + ((static_cast<double>(random())) / (static_cast<double>(RAND_MAX))) * (2 * maxNorm);
-        x[i] = a;
+        x[i] = unif(re);
     }
     return x;
 }
@@ -27,7 +30,7 @@ vector<double> printDebug(const Parameters &params, const Ciphertext &ciphertext
     cout << "Level: " << level(ciphertext) << " (logQ = " << logQLvl(params, level(ciphertext)) << ")" << endl;
     cout << "Scale: 2^" << log2(scale(ciphertext)) << endl;
 
-    cout << "Actual Result: " << setprecision(3) << actualPT[0] << " " << actualPT[1] << " " << actualPT[2] << " " << actualPT[3] << endl;
+    cout << "Actual Result:   " << setprecision(3) << actualPT[0] << " " << actualPT[1] << " " << actualPT[2] << " " << actualPT[3] << endl;
     cout << "Expected Result: " << setprecision(3) << expectedPT[0] << " " << expectedPT[1] << " " << expectedPT[2] << " " << expectedPT[3] << endl;
 
     string precStats = precisionStats(params, expectedPT, actualPT);
@@ -38,7 +41,6 @@ vector<double> printDebug(const Parameters &params, const Ciphertext &ciphertext
 }
 
 int main() {
-
     Parameters params = getParams(BootstrapParams0);
     BootstrappingParameters btpParams = getBootstrappingParams(BootstrapParams_Set2);
 
@@ -48,7 +50,7 @@ int main() {
          << ", sigma = " << sigma(params) << endl;
 
     KeyGenerator kgen = newKeyGenerator(params);
-    struct KeyPairHandle kp = genKeyPair(kgen);
+    struct KeyPairHandle kp = genKeyPairSparse(kgen, bootstrap_h(btpParams));
 
     Encoder encoder = newEncoder(params);
     Decryptor decryptor = newDecryptor(params, kp.sk);
@@ -60,7 +62,7 @@ int main() {
     cout << "Done" << endl;
 
     uint64_t num_slots = numSlots(params);
-    vector<double> values = randomVector(num_slots, 8);
+    vector<double> values = randomVector(num_slots, 1);
 
     Plaintext plaintext = encodeNTTAtLvlNew(params, encoder, values, maxLevel(params), scale(params));
 

--- a/examples/bootstrapping.cpp
+++ b/examples/bootstrapping.cpp
@@ -20,7 +20,7 @@ vector<double> randomVector(int dim, double maxNorm) {
     return x;
 }
 
-vector<double> printDebug(const Parameters &params, const Ciphertext &ciphertext, vector<double> &expectedPT, const Decryptor &decryptor, const Encoder encoder) {
+vector<double> printDebug(const Parameters &params, const Ciphertext &ciphertext, const vector<double> &expectedPT, const Decryptor &decryptor, const Encoder encoder) {
 
     vector<double> actualPT = decode(encoder, decryptNew(decryptor, ciphertext), logSlots(params));
 

--- a/examples/sigmoid.cpp
+++ b/examples/sigmoid.cpp
@@ -1,20 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "latticpp/ckks/ciphertext.h"
-#include "latticpp/ckks/decryptor.h"
-#include "latticpp/ckks/encoder.h"
-#include "latticpp/ckks/encryptor.h"
-#include "latticpp/ckks/evaluator.h"
-#include "latticpp/ckks/keygen.h"
-#include "latticpp/ckks/params.h"
-#include "latticpp/marshal/gohandle.h"
+#include "latticpp/latticpp.h"
 
 #include <cmath>
+#include <iomanip>
 #include <iostream>
 #include <map>
 #include <vector>
-#include <iomanip>
 
 using namespace std;
 using namespace latticpp;

--- a/src/gowrapper/CMakeLists.txt
+++ b/src/gowrapper/CMakeLists.txt
@@ -14,6 +14,8 @@
 add_custom_command(
   OUTPUT
     ${LATTIGO_LIB_FULL_PATH}
+    ${CGO_HEADER_DST}/bootstrap.h
+    ${CGO_HEADER_DST}/bootstrap_params.h
     ${CGO_HEADER_DST}/ciphertext.h
     ${CGO_HEADER_DST}/decryptor.h
     ${CGO_HEADER_DST}/encoder.h
@@ -22,6 +24,7 @@ add_custom_command(
     ${CGO_HEADER_DST}/keygen.h
     ${CGO_HEADER_DST}/marshaler.h
     ${CGO_HEADER_DST}/params.h
+    ${CGO_HEADER_DST}/precision.h
     ${CGO_HEADER_DST}/storage.h
   COMMAND cp -r ${CMAKE_CURRENT_SOURCE_DIR}/. .
 
@@ -29,7 +32,8 @@ add_custom_command(
   COMMAND go get github.com/ldsec/lattigo/v2/utils@v2.1.1
 
   COMMAND go vet
-
+  COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/ckks/bootstrap.go
+  COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/ckks/bootstrap_params.go
   COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/ckks/ciphertext.go
   COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/ckks/decryptor.go
   COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/ckks/encoder.go
@@ -38,8 +42,11 @@ add_custom_command(
   COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/ckks/keygen.go
   COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/ckks/marshaler.go
   COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/ckks/params.go
+  COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/ckks/precision.go
   COMMAND go fmt ${CMAKE_CURRENT_SOURCE_DIR}/marshal/storage.go
 
+  COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/bootstrap.h ckks/bootstrap.go
+  COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/bootstrap_params.h ckks/bootstrap_params.go
   COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/ciphertext.h ckks/ciphertext.go
   COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/decryptor.h ckks/decryptor.go
   COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/encoder.h ckks/encoder.go
@@ -48,11 +55,14 @@ add_custom_command(
   COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/keygen.h ckks/keygen.go
   COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/marshaler.h ckks/marshaler.go
   COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/params.h ckks/params.go
+  COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/precision.h ckks/precision.go
   COMMAND go tool cgo -exportheader ${CGO_HEADER_DST}/storage.h marshal/storage.go
   COMMAND go build -buildmode=c-shared -o ${LATTIGO_LIB_FULL_PATH}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS
     latticppMain.go
+    ckks/bootstrap.go
+    ckks/bootstrap_params.go
     ckks/ciphertext.go
     ckks/decryptor.go
     ckks/encoder.go
@@ -61,11 +71,14 @@ add_custom_command(
     ckks/keygen.go
     ckks/marshaler.go
     ckks/params.go
+    ckks/precision.go
     marshal/storage.go
     go.mod
 )
 
 add_library(latticpp_gowrapper STATIC
+    ${CGO_HEADER_DST}/bootstrap.h
+    ${CGO_HEADER_DST}/bootstrap_params.h
     ${CGO_HEADER_DST}/ciphertext.h
     ${CGO_HEADER_DST}/decryptor.h
     ${CGO_HEADER_DST}/encoder.h
@@ -74,6 +87,7 @@ add_library(latticpp_gowrapper STATIC
     ${CGO_HEADER_DST}/keygen.h
     ${CGO_HEADER_DST}/marshaler.h
     ${CGO_HEADER_DST}/params.h
+    ${CGO_HEADER_DST}/precision.h
     ${CGO_HEADER_DST}/storage.h)
 target_include_directories(latticpp_gowrapper PUBLIC ${CMAKE_BINARY_DIR})
 set_target_properties(latticpp_gowrapper PROPERTIES LINKER_LANGUAGE CXX)

--- a/src/gowrapper/ckks/bootstrap.go
+++ b/src/gowrapper/ckks/bootstrap.go
@@ -1,0 +1,50 @@
+package ckks
+
+import "C"
+
+import (
+	"github.com/ldsec/lattigo/v2/ckks"
+	"lattigo-cpp/marshal"
+	"unsafe"
+)
+
+// https://github.com/golang/go/issues/35715#issuecomment-791039692
+type Handle10 = uint64
+
+func getStoredBootstrapper(btpHandle Handle10) *ckks.Bootstrapper {
+	ref := marshal.CrossLangObjMap.Get(btpHandle)
+	return (*ckks.Bootstrapper)(ref.Ptr)
+}
+
+//export lattigo_newBootstrapper
+func lattigo_newBootstrapper(paramHandle Handle10, btpParamHandle Handle10, btpKeyHandle Handle10) Handle10 {
+	var params *ckks.Parameters
+	params = getStoredParameters(paramHandle)
+
+	var btpParams *ckks.BootstrappingParameters
+	btpParams = getStoredBootstrappingParameters(btpParamHandle)
+
+	var btpKey *ckks.BootstrappingKey
+	btpKey = getStoredBootstrappingKey(btpKeyHandle)
+
+	var btp *ckks.Bootstrapper
+	var err error
+	btp, err = ckks.NewBootstrapper(params, btpParams, btpKey)
+	if err != nil {
+		panic(err)
+	}
+	return marshal.CrossLangObjMap.Add(unsafe.Pointer(btp))
+}
+
+//export lattigo_bootstrap
+func lattigo_bootstrap(btpHandle Handle10, ctHandle Handle10) Handle10 {
+	var btp *ckks.Bootstrapper
+	btp = getStoredBootstrapper(btpHandle)
+
+	var ctIn *ckks.Ciphertext
+	ctIn = getStoredCiphertext(ctHandle)
+
+	var ctOut *ckks.Ciphertext
+	ctOut = btp.Bootstrapp(ctIn)
+	return marshal.CrossLangObjMap.Add(unsafe.Pointer(ctOut))
+}

--- a/src/gowrapper/ckks/bootstrap_params.go
+++ b/src/gowrapper/ckks/bootstrap_params.go
@@ -1,0 +1,33 @@
+package ckks
+
+import "C"
+
+import (
+	"github.com/ldsec/lattigo/v2/ckks"
+	"lattigo-cpp/marshal"
+	"unsafe"
+)
+
+// https://github.com/golang/go/issues/35715#issuecomment-791039692
+type Handle11 = uint64
+
+func getStoredBootstrappingParameters(bootParamHandle Handle11) *ckks.BootstrappingParameters {
+	ref := marshal.CrossLangObjMap.Get(bootParamHandle)
+	return (*ckks.BootstrappingParameters)(ref.Ptr)
+}
+
+//export lattigo_getBootstrappingParams
+func lattigo_getBootstrappingParams(bootParamEnum uint8) Handle11 {
+	var bootParams *ckks.BootstrappingParameters
+
+	bootParams = ckks.DefaultBootstrapParams[bootParamEnum]
+
+	return marshal.CrossLangObjMap.Add(unsafe.Pointer(bootParams))
+}
+
+//export lattigo_bootstrap_h
+func lattigo_bootstrap_h(bootParamHandle Handle11) uint64 {
+	var bootParams *ckks.BootstrappingParameters
+	bootParams = getStoredBootstrappingParameters(bootParamHandle)
+	return bootParams.H
+}

--- a/src/gowrapper/ckks/decryptor.go
+++ b/src/gowrapper/ckks/decryptor.go
@@ -11,8 +11,8 @@ import (
 // https://github.com/golang/go/issues/35715#issuecomment-791039692
 type Handle1 = uint64
 
-func getStoredDecryptor(decryptoHandle Handle8) *ckks.Decryptor {
-	ref := marshal.CrossLangObjMap.Get(decryptoHandle)
+func getStoredDecryptor(decryptorHandle Handle1) *ckks.Decryptor {
+	ref := marshal.CrossLangObjMap.Get(decryptorHandle)
 	return (*ckks.Decryptor)(ref.Ptr)
 }
 
@@ -26,9 +26,9 @@ func lattigo_newDecryptor(paramHandle Handle1, skHandle Handle1) Handle1 {
 }
 
 //export lattigo_decryptNew
-func lattigo_decryptNew(decryptoHandle Handle1, ctHandle Handle1) Handle1 {
+func lattigo_decryptNew(decryptorHandle Handle1, ctHandle Handle1) Handle1 {
 	var dec *ckks.Decryptor
-	dec = getStoredDecryptor(decryptoHandle)
+	dec = getStoredDecryptor(decryptorHandle)
 
 	var ct *ckks.Ciphertext
 	ct = getStoredCiphertext(ctHandle)

--- a/src/gowrapper/ckks/keygen.go
+++ b/src/gowrapper/ckks/keygen.go
@@ -73,6 +73,19 @@ func lattigo_genKeyPair(keygenHandle Handle5) C.struct_Lattigo_KeyPairHandle {
 	return kpHandle
 }
 
+//export lattigo_genKeyPairSparse
+func lattigo_genKeyPairSparse(keygenHandle Handle5, hw uint64) C.struct_Lattigo_KeyPairHandle {
+	var keygen *ckks.KeyGenerator
+	keygen = getStoredKeyGenerator(keygenHandle)
+	var sk *ckks.SecretKey
+	var pk *ckks.PublicKey
+	sk, pk = (*keygen).GenKeyPairSparse(hw)
+	var kpHandle C.struct_Lattigo_KeyPairHandle
+	kpHandle.sk = C.uint64_t(marshal.CrossLangObjMap.Add(unsafe.Pointer(sk)))
+	kpHandle.pk = C.uint64_t(marshal.CrossLangObjMap.Add(unsafe.Pointer(pk)))
+	return kpHandle
+}
+
 //export lattigo_genRelinKey
 func lattigo_genRelinKey(keygenHandle Handle5, skHandle Handle5) Handle5 {
 	var keygen *ckks.KeyGenerator

--- a/src/gowrapper/ckks/keygen.go
+++ b/src/gowrapper/ckks/keygen.go
@@ -4,11 +4,13 @@ package ckks
 // but the auto-generated struct with generated names loses its semantic value. We opt
 // to define our own struct here.
 
-// #include "stdint.h"
-// struct Lattigo_KeyPairHandle {
-//   uint64_t sk;
-//   uint64_t pk;
-// };
+/*
+#include "stdint.h"
+struct Lattigo_KeyPairHandle {
+  uint64_t sk;
+  uint64_t pk;
+};
+*/
 import "C"
 
 import (
@@ -35,14 +37,19 @@ func getStoredPublicKey(pkHandle Handle5) *ckks.PublicKey {
 	return (*ckks.PublicKey)(ref.Ptr)
 }
 
-func getStoredEvalKey(evalKeyHandle Handle4) *ckks.EvaluationKey {
+func getStoredEvalKey(evalKeyHandle Handle5) *ckks.EvaluationKey {
 	ref := marshal.CrossLangObjMap.Get(evalKeyHandle)
 	return (*ckks.EvaluationKey)(ref.Ptr)
 }
 
-func getStoredRotationKeys(rotKeysHandle Handle4) *ckks.RotationKeys {
+func getStoredRotationKeys(rotKeysHandle Handle5) *ckks.RotationKeys {
 	ref := marshal.CrossLangObjMap.Get(rotKeysHandle)
 	return (*ckks.RotationKeys)(ref.Ptr)
+}
+
+func getStoredBootstrappingKey(bootKeyHandle Handle5) *ckks.BootstrappingKey {
+	ref := marshal.CrossLangObjMap.Get(bootKeyHandle)
+	return (*ckks.BootstrappingKey)(ref.Ptr)
 }
 
 //export lattigo_newKeyGenerator
@@ -84,4 +91,20 @@ func lattigo_genRotationKeysPow2(keygenHandle Handle5, skHandle Handle5) Handle5
 	var rotKeys *ckks.RotationKeys
 	rotKeys = (*keygen).GenRotationKeysPow2(sk)
 	return marshal.CrossLangObjMap.Add(unsafe.Pointer(rotKeys))
+}
+
+//export lattigo_genBootstrappingKey
+func lattigo_genBootstrappingKey(keygenHandle Handle5, logSlots uint64, btpParamsHandle Handle5, skHandle Handle5) Handle5 {
+	var keygen *ckks.KeyGenerator
+	keygen = getStoredKeyGenerator(keygenHandle)
+
+	var sk *ckks.SecretKey
+	sk = getStoredSecretKey(skHandle)
+
+	var btpParams *ckks.BootstrappingParameters
+	btpParams = getStoredBootstrappingParameters(btpParamsHandle)
+
+	var btpKey *ckks.BootstrappingKey
+	btpKey = (*keygen).GenBootstrappingKey(logSlots, btpParams, sk)
+	return marshal.CrossLangObjMap.Add(unsafe.Pointer(btpKey))
 }

--- a/src/gowrapper/ckks/params.go
+++ b/src/gowrapper/ckks/params.go
@@ -1,5 +1,9 @@
 package ckks
 
+/*
+#include "stdint.h"
+typedef const uint8_t constUChar;
+*/
 import "C"
 
 import (
@@ -19,12 +23,18 @@ func getStoredParameters(paramHandle Handle6) *ckks.Parameters {
 //export lattigo_getParams
 func lattigo_getParams(paramEnum uint8) Handle6 {
 	var params *ckks.Parameters
-	params = ckks.DefaultParams[paramEnum]
+
+	if int(paramEnum) < len(ckks.DefaultParams) {
+		params = ckks.DefaultParams[paramEnum]
+	} else {
+		params = ckks.DefaultBootstrapSchemeParams[int(paramEnum)-len(ckks.DefaultParams)]
+	}
+
 	return marshal.CrossLangObjMap.Add(unsafe.Pointer(params))
 }
 
 //export lattigo_newParametersFromLogModuli
-func lattigo_newParametersFromLogModuli(logN uint64, logQi *C.uchar, numQi uint8, logPi *C.uchar, numPi uint8, logScale uint8) Handle6 {
+func lattigo_newParametersFromLogModuli(logN uint64, logQi *C.constUChar, numQi uint8, logPi *C.constUChar, numPi uint8, logScale uint8) Handle6 {
 	size := unsafe.Sizeof(uint8(0))
 
 	LogQi := make([]uint64, numQi)

--- a/src/gowrapper/ckks/plaintext.go
+++ b/src/gowrapper/ckks/plaintext.go
@@ -10,7 +10,7 @@ import (
 // https://github.com/golang/go/issues/35715#issuecomment-791039692
 type Handle7 = uint64
 
-func getStoredPlaintext(ptHandle uint64) *ckks.Plaintext {
+func getStoredPlaintext(ptHandle Handle7) *ckks.Plaintext {
     ref := marshal.CrossLangObjMap.Get(ptHandle)
     return (*ckks.Plaintext)(ref.Ptr)
 }

--- a/src/gowrapper/ckks/precision.go
+++ b/src/gowrapper/ckks/precision.go
@@ -1,0 +1,34 @@
+package ckks
+
+/*
+typedef const double constDouble;
+
+#include "stdint.h"
+struct Lattigo_String {
+  char *data;
+  uint64_t len;
+};
+*/
+import "C"
+
+import (
+	"github.com/ldsec/lattigo/v2/ckks"
+)
+
+// https://github.com/golang/go/issues/35715#issuecomment-791039692
+type Handle12 = uint64
+
+//export lattigo_precisionStats
+func lattigo_precisionStats(paramHandle Handle12, expectedValues *C.constDouble, actualValues *C.constDouble, length uint64) *C.char {
+
+	var params *ckks.Parameters
+	params = getStoredParameters(paramHandle)
+
+	expectedComplexValues := CDoubleVecToGoComplex(expectedValues, length)
+	actualComplexValues := CDoubleVecToGoComplex(actualValues, length)
+
+	var prec ckks.PrecisionStats
+	prec = ckks.GetPrecisionStats(params, nil, nil, expectedComplexValues, actualComplexValues)
+
+	return C.CString(prec.String())
+}

--- a/src/latticpp/ckks/CMakeLists.txt
+++ b/src/latticpp/ckks/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 target_sources(latticpp_obj
     PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/bootstrap.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/bootstrap_params.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ciphertext.cpp
         ${CMAKE_CURRENT_LIST_DIR}/decryptor.cpp
         ${CMAKE_CURRENT_LIST_DIR}/encoder.cpp
@@ -11,10 +13,13 @@ target_sources(latticpp_obj
         ${CMAKE_CURRENT_LIST_DIR}/keygen.cpp
         ${CMAKE_CURRENT_LIST_DIR}/marshaler.cpp
         ${CMAKE_CURRENT_LIST_DIR}/params.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/precision.cpp
 )
 
 install(
     FILES
+        ${CMAKE_CURRENT_LIST_DIR}/bootstrap.h
+        ${CMAKE_CURRENT_LIST_DIR}/bootstrap_params.h
         ${CMAKE_CURRENT_LIST_DIR}/ciphertext.h
         ${CMAKE_CURRENT_LIST_DIR}/decryptor.h
         ${CMAKE_CURRENT_LIST_DIR}/encoder.h
@@ -23,6 +28,7 @@ install(
         ${CMAKE_CURRENT_LIST_DIR}/keygen.h
         ${CMAKE_CURRENT_LIST_DIR}/marshaler.h
         ${CMAKE_CURRENT_LIST_DIR}/params.h
+        ${CMAKE_CURRENT_LIST_DIR}/precision.h
     DESTINATION
         ${LATTICPP_INCLUDES_INSTALL_DIR}/ckks
 )

--- a/src/latticpp/ckks/bootstrap.cpp
+++ b/src/latticpp/ckks/bootstrap.cpp
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bootstrap.h"
+
+using namespace std;
+
+namespace latticpp {
+
+    Bootstrapper newBootstrapper(const Parameters &params, const BootstrappingParameters &bootParams, const BootstrappingKey &bootKey) {
+        return Bootstrapper(lattigo_newBootstrapper(params.getRawHandle(), bootParams.getRawHandle(), bootKey.getRawHandle()));
+    }
+
+    Ciphertext bootstrap(const Bootstrapper &btp, const Ciphertext &ct) {
+        return Ciphertext(lattigo_bootstrap(btp.getRawHandle(), ct.getRawHandle()));
+    }
+}  // namespace latticpp

--- a/src/latticpp/ckks/bootstrap.h
+++ b/src/latticpp/ckks/bootstrap.h
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "latticpp/marshal/gohandle.h"
+#include "cgo/bootstrap.h"
+
+namespace latticpp {
+
+    Bootstrapper newBootstrapper(const Parameters &params, const BootstrappingParameters &bootParams, const BootstrappingKey &bootKey);
+
+    Ciphertext bootstrap(const Bootstrapper &btp, const Ciphertext &ct);
+}  // namespace latticpp

--- a/src/latticpp/ckks/bootstrap_params.cpp
+++ b/src/latticpp/ckks/bootstrap_params.cpp
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bootstrap_params.h"
+
+using namespace std;
+
+namespace latticpp {
+
+    BootstrappingParameters getBootstrappingParams(const NamedBootstrappingParams paramId) {
+        return BootstrappingParameters(lattigo_getBootstrappingParams(paramId));
+    }
+
+    uint64_t bootstrap_h(const BootstrappingParameters &bootParamHandle) {
+        return lattigo_bootstrap_h(bootParamHandle.getRawHandle());
+    }
+}  // namespace latticpp

--- a/src/latticpp/ckks/bootstrap_params.h
+++ b/src/latticpp/ckks/bootstrap_params.h
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "latticpp/marshal/gohandle.h"
+#include "cgo/bootstrap_params.h"
+
+namespace latticpp {
+
+    enum NamedBootstrappingParams {
+        // Bootstrapping parameters index 0
+        BootstrapParams_Set2,
+        // Bootstrapping parameters index 1
+        BootstrapParams_Set5,
+        // Bootstrapping parameters index 2
+        BootstrapParams_Set7,
+        // Bootstrapping parameters index 3
+        BootstrapParams_Set4
+    };
+
+    BootstrappingParameters getBootstrappingParams(const NamedBootstrappingParams paramId);
+
+    uint64_t bootstrap_h(const BootstrappingParameters &bootParamHandle);
+}  // namespace latticpp

--- a/src/latticpp/ckks/keygen.cpp
+++ b/src/latticpp/ckks/keygen.cpp
@@ -14,6 +14,11 @@ namespace latticpp {
         return KeyPairHandle { SecretKey(kp.sk), PublicKey(kp.pk) };
     }
 
+    KeyPairHandle genKeyPairSparse(const KeyGenerator &keygen, uint64_t hw) {
+        Lattigo_KeyPairHandle kp = lattigo_genKeyPairSparse(keygen.getRawHandle(), hw);
+        return KeyPairHandle { SecretKey(kp.sk), PublicKey(kp.pk) };
+    }
+
     EvaluationKey genRelinKey(const KeyGenerator &keygen, const SecretKey &sk) {
         return EvaluationKey(lattigo_genRelinKey(keygen.getRawHandle(), sk.getRawHandle()));
     }

--- a/src/latticpp/ckks/keygen.cpp
+++ b/src/latticpp/ckks/keygen.cpp
@@ -21,4 +21,8 @@ namespace latticpp {
     RotationKeys genRotationKeysPow2(const KeyGenerator &keygen, const SecretKey &sk) {
         return RotationKeys(lattigo_genRotationKeysPow2(keygen.getRawHandle(), sk.getRawHandle()));
     }
+
+    BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, uint64_t logSlots, const BootstrappingParameters &bootParams, const SecretKey &sk) {
+        return BootstrappingKey(lattigo_genBootstrappingKey(keygen.getRawHandle(), logSlots, bootParams.getRawHandle(), sk.getRawHandle()));
+    }
 }  // namespace latticpp

--- a/src/latticpp/ckks/keygen.h
+++ b/src/latticpp/ckks/keygen.h
@@ -17,6 +17,8 @@ namespace latticpp {
 
     KeyPairHandle genKeyPair(const KeyGenerator &keygen);
 
+    KeyPairHandle genKeyPairSparse(const KeyGenerator &keygen, uint64_t hw);
+
     EvaluationKey genRelinKey(const KeyGenerator &keygen, const SecretKey &sk);
 
     RotationKeys genRotationKeysPow2(const KeyGenerator &keygen, const SecretKey &sk);

--- a/src/latticpp/ckks/keygen.h
+++ b/src/latticpp/ckks/keygen.h
@@ -20,4 +20,6 @@ namespace latticpp {
     EvaluationKey genRelinKey(const KeyGenerator &keygen, const SecretKey &sk);
 
     RotationKeys genRotationKeysPow2(const KeyGenerator &keygen, const SecretKey &sk);
+
+    BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, uint64_t logSlots, const BootstrappingParameters &bootParams, const SecretKey &sk);
 }  // namespace latticpp

--- a/src/latticpp/ckks/params.cpp
+++ b/src/latticpp/ckks/params.cpp
@@ -7,11 +7,11 @@ using namespace std;
 
 namespace latticpp {
 
-    Parameters getParams(HEParams paramId) {
+    Parameters getParams(NamedCKKSParams paramId) {
         return Parameters(lattigo_getParams(paramId));
     }
 
-    Parameters newParametersFromLogModuli(uint64_t logN, vector<uint8_t> logQi, uint8_t numQi, vector<uint8_t> logPi, uint8_t numPi, uint8_t logScale) {
+    Parameters newParametersFromLogModuli(uint64_t logN, const vector<uint8_t> &logQi, uint8_t numQi, const vector<uint8_t> &logPi, uint8_t numPi, uint8_t logScale) {
         return Parameters(lattigo_newParametersFromLogModuli(logN, logQi.data(), numQi, logPi.data(), numPi, logScale));
     }
 

--- a/src/latticpp/ckks/params.h
+++ b/src/latticpp/ckks/params.h
@@ -9,7 +9,7 @@
 
 namespace latticpp {
 
-    enum HEParams {
+    enum NamedCKKSParams {
         // PN12QP109 is the index in DefaultParams for logQP = 109
         PN12QP109,
         // PN13QP218 is the index in DefaultParams for logQP = 218
@@ -29,13 +29,21 @@ namespace latticpp {
         // PN15QP827pq is the index in DefaultParams for logQP = 827 (post quantum)
         PN15QP827pq,
         // PN16QP1654pq is the index in DefaultParams for logQP = 1654 (post quantum)
-        PN16QP1654pq
+        PN16QP1654pq,
+        // Bootstrapping parameters index 0
+        BootstrapParams0,
+        // Bootstrapping parameters index 1
+        BootstrapParams1,
+        // Bootstrapping parameters index 2
+        BootstrapParams2,
+        // Bootstrapping parameters index 3
+        BootstrapParams3
     };
 
-    Parameters getParams(HEParams paramId);
+    Parameters getParams(NamedCKKSParams paramId);
 
     // logN is the log of the polynomial ring degree. Alternatively, it is log(num_slots) + 1
-    Parameters newParametersFromLogModuli(uint64_t logN, std::vector<uint8_t> logQi, uint8_t numQi, std::vector<uint8_t> logPi, uint8_t numPi, uint8_t logScale);
+    Parameters newParametersFromLogModuli(uint64_t logN, const std::vector<uint8_t> &logQi, uint8_t numQi, const std::vector<uint8_t> &logPi, uint8_t numPi, uint8_t logScale);
 
     uint64_t numSlots(const Parameters &params);
 

--- a/src/latticpp/ckks/precision.cpp
+++ b/src/latticpp/ckks/precision.cpp
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "precision.h"
+
+using namespace std;
+
+namespace latticpp {
+
+
+    std::string precisionStats(const Parameters &params, const std::vector<double> &expectedValues, const std::vector<double> &actualValues) {
+        int len = expectedValues.size();
+        if (len != actualValues.size()) {
+            throw invalid_argument("Inputs to precisionStats do not have the same length.");
+        }
+
+        char* strData = lattigo_precisionStats(params.getRawHandle(), expectedValues.data(), actualValues.data(), len);
+        string str = string(strData);
+        free(strData);
+        return str;
+    }
+}  // namespace latticpp

--- a/src/latticpp/ckks/precision.h
+++ b/src/latticpp/ckks/precision.h
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "latticpp/marshal/gohandle.h"
+#include "cgo/precision.h"
+#include <vector>
+#include <string>
+
+namespace latticpp {
+
+    std::string precisionStats(const Parameters &params, const std::vector<double> &expectedValues, const std::vector<double> &actualValues);
+}  // namespace latticpp

--- a/src/latticpp/latticpp.h
+++ b/src/latticpp/latticpp.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "latticpp/ckks/bootstrap.h"
+#include "latticpp/ckks/bootstrap_params.h"
 #include "latticpp/ckks/ciphertext.h"
 #include "latticpp/ckks/decryptor.h"
 #include "latticpp/ckks/encoder.h"
@@ -11,4 +13,5 @@
 #include "latticpp/ckks/keygen.h"
 #include "latticpp/ckks/marshaler.h"
 #include "latticpp/ckks/params.h"
+#include "latticpp/ckks/precision.h"
 #include "latticpp/marshal/gohandle.h"

--- a/src/latticpp/marshal/gohandle.h
+++ b/src/latticpp/marshal/gohandle.h
@@ -13,6 +13,9 @@
 namespace latticpp {
 
     enum class GoType {
+        Bootstrapper,
+        BootstrappingParameters,
+        BootstrappingKey,
         Parameters,
         Encoder,
         KeyGenerator,
@@ -144,6 +147,9 @@ namespace latticpp {
         uint64_t handle;
     };
 
+    using Bootstrapper = GoHandle<GoType::Bootstrapper>;
+    using BootstrappingKey = GoHandle<GoType::BootstrappingKey>;
+    using BootstrappingParameters = GoHandle<GoType::BootstrappingParameters>;
     using Parameters = GoHandle<GoType::Parameters>;
     using Encoder = GoHandle<GoType::Encoder>;
     using KeyGenerator = GoHandle<GoType::KeyGenerator>;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds support for bootstrapping. It introduces the new types `Bootstrapper`, `BootstrappingKey` and `BootstrappingParameters`, plus associated APIs. Added a new example that mirrors the Lattigo example for bootstrapping.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
