### PR TITLE
Bootstrapping serialization

### DIFF
--- a/src/gowrapper/ckks/keygen.go
+++ b/src/gowrapper/ckks/keygen.go
@@ -207,3 +207,18 @@ func lattigo_genBootstrappingKey(keygenHandle Handle5, paramHandle Handle5, btpP
 
 	return marshal.CrossLangObjMap.Add(unsafe.Pointer(&btpKey))
 }
+
+//export lattigo_makeBootstrappingKey
+func lattigo_makeBootstrappingKey(relinKeyHandle Handle5, rotKeyHandle Handle5) Handle5 {
+	// get existing keys
+	var relinKey *rlwe.RelinearizationKey
+	relinKey = getStoredRelinKey(relinKeyHandle)
+
+	var rotKeys *rlwe.RotationKeySet
+	rotKeys = getStoredRotationKeys(rotKeyHandle)
+
+	var btpKey ckks.BootstrappingKey
+	btpKey = ckks.BootstrappingKey{Rlk: relinKey, Rtks: rotKeys}
+
+	return marshal.CrossLangObjMap.Add(unsafe.Pointer(&btpKey))
+}

--- a/src/gowrapper/ckks/marshaler.go
+++ b/src/gowrapper/ckks/marshaler.go
@@ -57,6 +57,22 @@ func lattigo_marshalBinaryParameters(paramsHandle Handle9, callback C.streamWrit
 	}
 }
 
+//export lattigo_marshalBinaryBootstrapParameters
+func lattigo_marshalBinaryBootstrapParameters(paramsHandle Handle9, callback C.streamWriter, stream *C.void) {
+	// var params *ckks.BootstrappingParameters
+	// params = getStoredBootstrappingParameters(paramsHandle)
+
+	// data, err := params.MarshalBinary()
+	// if err != nil {
+	// 	panic(err)
+	// }
+	var data []byte
+
+	if len(data) > 0 {
+		C.callStreamWriter(callback, unsafe.Pointer(stream), unsafe.Pointer(&data[0]), C.uint64_t(len(data)))
+	}
+}
+
 //export lattigo_marshalBinarySecretKey
 func lattigo_marshalBinarySecretKey(skHandle Handle9, callback C.streamWriter, stream *C.void) {
 	var sk *rlwe.SecretKey

--- a/src/latticpp/ckks/keygen.cpp
+++ b/src/latticpp/ckks/keygen.cpp
@@ -41,4 +41,8 @@ namespace latticpp {
     BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys) {
         return BootstrappingKey(lattigo_genBootstrappingKey(keygen.getRawHandle(), params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle(), relinKey.getRawHandle(), rotKeys.getRawHandle()));
     }
+
+    BootstrappingKey makeBootstrappingKey(const RelinearizationKey &relinKey, const RotationKeys &rotKeys) {
+        return BootstrappingKey(lattigo_makeBootstrappingKey(relinKey.getRawHandle(), rotKeys.getRawHandle()));
+    }
 }  // namespace latticpp

--- a/src/latticpp/ckks/keygen.h
+++ b/src/latticpp/ckks/keygen.h
@@ -27,4 +27,7 @@ namespace latticpp {
     EvaluationKey makeEvaluationKey(const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
 
     BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
+
+    BootstrappingKey makeBootstrappingKey(const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
+
 }  // namespace latticpp

--- a/src/latticpp/ckks/marshaler.cpp
+++ b/src/latticpp/ckks/marshaler.cpp
@@ -57,6 +57,11 @@ namespace latticpp {
         return Parameters(lattigo_unmarshalBinaryParameters(buffer.data(), buffer.size()));
     }
 
+    BootstrappingParameters unmarshalBinaryBootstrapParameters(std::istream &stream) {
+        vector<char> buffer(istreambuf_iterator<char>{stream}, {});
+        return BootstrappingParameters(lattigo_unmarshalBinaryBootstrapParameters(buffer.data(), buffer.size()));
+    }
+
     SecretKey unmarshalBinarySecretKey(istream &stream) {
         vector<char> buffer(istreambuf_iterator<char>{stream}, {});
         return SecretKey(lattigo_unmarshalBinarySecretKey(buffer.data(), buffer.size()));

--- a/src/latticpp/ckks/marshaler.cpp
+++ b/src/latticpp/ckks/marshaler.cpp
@@ -22,6 +22,10 @@ namespace latticpp {
         lattigo_marshalBinaryParameters(params.getRawHandle(), &writeToStream, (void*)(&stream));
     }
 
+    void marshalBinaryBootstrapParameters(const BootstrappingParameters &btp_params, std::ostream &stream) {
+        lattigo_marshalBinaryBootstrapParameters(btp_params.getRawHandle(), &writeToStream, (void*)(&stream));
+    }
+
     void marshalBinarySecretKey(const SecretKey &sk, std::ostream &stream) {
         lattigo_marshalBinarySecretKey(sk.getRawHandle(), &writeToStream, (void*)(&stream));
     }

--- a/src/latticpp/ckks/marshaler.h
+++ b/src/latticpp/ckks/marshaler.h
@@ -26,6 +26,8 @@ namespace latticpp {
 
     Parameters unmarshalBinaryParameters(std::istream &stream);
 
+    BootstrappingParameters unmarshalBinaryBootstrapParameters(std::istream &stream);
+
     SecretKey unmarshalBinarySecretKey(std::istream &stream);
 
     PublicKey unmarshalBinaryPublicKey(std::istream &stream);

--- a/src/latticpp/ckks/marshaler.h
+++ b/src/latticpp/ckks/marshaler.h
@@ -12,6 +12,8 @@ namespace latticpp {
 
     void marshalBinaryParameters(const Parameters &params, std::ostream &stream);
 
+    void marshalBinaryBootstrapParameters(const BootstrappingParameters &btp_params, std::ostream &stream);
+
     void marshalBinarySecretKey(const SecretKey &sk, std::ostream &stream);
 
     void marshalBinaryPublicKey(const PublicKey &pk, std::ostream &stream);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds serialization of bootstrapping parameters. The latest version of Lattigo doesn't support direct serialization of BootstrappingParameters (https://github.com/ldsec/lattigo/issues/140), so they suggested using generic support from the Go language.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
