### PR TITLE
Support sparse bootstrappable presets

### DIFF
--- a/src/gowrapper/ckks/bootstrap_params.go
+++ b/src/gowrapper/ckks/bootstrap_params.go
@@ -24,7 +24,9 @@ func getStoredBootstrappingParameters(bootParamHandle Handle11) *bootstrapping.P
 
 //export lattigo_getBootstrappingParams
 func lattigo_getBootstrappingParams(bootParamEnum uint8) Handle11 {
+	// concat the dense and sparse params
 	defaultParameters := bootstrapping.DefaultParametersDense
+	defaultParameters = append(defaultParameters, bootstrapping.DefaultParametersSparse...)
 
 	if int(bootParamEnum) >= len(defaultParameters) {
 		panic(errors.New("bootstrapping parameter enum index out of bounds"))
@@ -44,7 +46,9 @@ func lattigo_ephemeralSecretWeight(bootParamHandle Handle11) uint64 {
 
 //export lattigo_params
 func lattigo_params(bootParamEnum uint8) Handle11 {
+	// concat the dense and sparse params
 	defaultParameters := bootstrapping.DefaultParametersDense
+	defaultParameters = append(defaultParameters, bootstrapping.DefaultParametersSparse...)
 
 	if int(bootParamEnum) >= len(defaultParameters) {
 		panic(errors.New("bootstrapping parameter enum index out of bounds"))

--- a/src/latticpp/ckks/bootstrap_params.h
+++ b/src/latticpp/ckks/bootstrap_params.h
@@ -10,10 +10,17 @@ namespace latticpp {
 
     // These correspond to the default bootstrapping parameters provided in Lattigo
     enum NamedBootstrappingParams {
+        //DENSE
         N16QP1767H32768H32,
         N16QP1788H32768H32,
         N16QP1793H32768H32,
-        N15QP880H16384H32
+        N15QP880H16384H32,
+
+        //SPARSE
+        N16QP1546H192H32,
+        N16QP1547H192H32,
+        N16QP1553H192H32,
+        N15QP768H192H32
     };
 
     BootstrappingParameters getBootstrappingParams(const NamedBootstrappingParams paramId);


### PR DESCRIPTION
*Issue #20* 

*Description of changes:*
This PR adds the option to use more bootstrappable presets that available in Lattigo V4.1.0.
More specific, we add SPARSE presets on top the existing DENSE presets. 

The code does not change any external api and so no regression is expected due to this change. Examples were tested and completed successfully.

See Lattigo V4.1.0 default presets for bootstrapping:
https://github.com/tuneinsight/lattigo/blob/adf762375670e412bab261cd7ffff9ca03777ad5/ckks/bootstrapping/default_params.go#L20



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
