### PR TITLE
Support generating bootstrapping keys at the server side. 

### DIFF
--- a/examples/bootstrapping.cpp
+++ b/examples/bootstrapping.cpp
@@ -59,9 +59,7 @@ int main() {
     Encryptor encryptor = newEncryptor(params, kp.pk);
 
     cout << "Generating bootstrapping keys..." << endl;
-    RelinearizationKey relinKey = genRelinKey(kgen, kp.sk);
-    RotationKeys rotKeys = genRotationKeysForRotations(kgen, kp.sk, vector<int>());
-    BootstrappingKey btpKey = genBootstrappingKey(kgen, params, btpParams, kp.sk, relinKey, rotKeys);
+    BootstrappingKey btpKey = genBootstrappingKey(kgen, params, btpParams, kp.sk);
     Bootstrapper btp = newBootstrapper(params, btpParams, btpKey);
     cout << "Done" << endl;
 

--- a/src/gowrapper/ckks/keygen.go
+++ b/src/gowrapper/ckks/keygen.go
@@ -196,8 +196,6 @@ func lattigo_genRotationKeysForRotations(keygenHandle Handle5, skHandle Handle5,
 	}
 	includeConjugateVal := (includeConjugate == 1)
 	var rotKeys *rlwe.RotationKeySet
-	// The second argument determines if conjugation keys are generated or not. This wrapper API does
-	// not support generating a conjugation key.
 	rotKeys = (*keygen).GenRotationKeysForRotations(rotations, includeConjugateVal, sk)
 	return marshal.CrossLangObjMap.Add(unsafe.Pointer(rotKeys))
 }

--- a/src/gowrapper/ckks/keygen.go
+++ b/src/gowrapper/ckks/keygen.go
@@ -21,11 +21,12 @@ struct Lattigo_BootstrapSwkPairHandle {
 import "C"
 
 import (
+	"lattigo-cpp/marshal"
+	"unsafe"
+
 	"github.com/tuneinsight/lattigo/v4/ckks"
 	"github.com/tuneinsight/lattigo/v4/ckks/bootstrapping"
 	"github.com/tuneinsight/lattigo/v4/rlwe"
-	"lattigo-cpp/marshal"
-	"unsafe"
 )
 
 // https://github.com/golang/go/issues/35715#issuecomment-791039692
@@ -339,7 +340,7 @@ func lattigo_setRotKeysForEvaluationKey(evalKeyHandle Handle5, rotKeysHandle Han
 }
 
 //export lattigo_genBootstrappingKey
-func lattigo_genBootstrappingKey(keygenHandle Handle5, paramHandle Handle5, btpParamsHandle Handle5, skHandle Handle5, relinKeyHandle Handle5, rotKeyHandle Handle5) Handle5 {
+func lattigo_genBootstrappingKey(keygenHandle Handle5, paramHandle Handle5, btpParamsHandle Handle5, skHandle Handle5) Handle5 {
 	var params *ckks.Parameters
 	params = getStoredParameters(paramHandle)
 

--- a/src/latticpp/ckks/keygen.cpp
+++ b/src/latticpp/ckks/keygen.cpp
@@ -98,10 +98,6 @@ namespace latticpp {
         return RelinearizationKey(lattigo_genRelinearizationKey(keygen.getRawHandle(), sk.getRawHandle()));
     }
 
-    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, vector<int> shifts) {
-      return genRotationKeysForRotations(keygen, sk, shifts, false);
-    }
-
     RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, vector<int> shifts, int includeConjugate) {
         // convert from variable-sized int to fixed-size SIGNED int64_t
         vector<int64_t> fixed_width_shifts(shifts.size());
@@ -141,11 +137,6 @@ namespace latticpp {
                                     const RotationKeys &rotKeys) {
       lattigo_setRotKeysForEvaluationKey(evalKey.getRawHandle(),
                                          rotKeys.getRawHandle());
-    }
-
-    // DEPRACATED
-    BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey & /*relinKey*/, const RotationKeys &/*rotKeys*/) {
-        return genBootstrappingKey(keygen, params, bootParams, sk);
     }
 
   BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk) {

--- a/src/latticpp/ckks/keygen.cpp
+++ b/src/latticpp/ckks/keygen.cpp
@@ -98,13 +98,13 @@ namespace latticpp {
         return RelinearizationKey(lattigo_genRelinearizationKey(keygen.getRawHandle(), sk.getRawHandle()));
     }
 
-    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, vector<int> shifts) {
+    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, vector<int> shifts, int includeConjugate) {
         // convert from variable-sized int to fixed-size SIGNED int64_t
         vector<int64_t> fixed_width_shifts(shifts.size());
         for (int i = 0; i < shifts.size(); i++) {
             fixed_width_shifts[i] = static_cast<int64_t>(shifts[i]);
         }
-        return RotationKeys(lattigo_genRotationKeysForRotations(keygen.getRawHandle(), sk.getRawHandle(), fixed_width_shifts.data(), shifts.size()));
+        return RotationKeys(lattigo_genRotationKeysForRotations(keygen.getRawHandle(), sk.getRawHandle(), fixed_width_shifts.data(), shifts.size(), includeConjugate));
     }
 
     CiphertextQP getCiphertextQP(const SwitchingKey &swk, uint64_t i, uint64_t j) {
@@ -141,6 +141,18 @@ namespace latticpp {
 
     BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys) {
         return BootstrappingKey(lattigo_genBootstrappingKey(keygen.getRawHandle(), params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle(), relinKey.getRawHandle(), rotKeys.getRawHandle()));
+    }
+
+    BootstrappingKey genBootstrappingKey2(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys) {
+        return BootstrappingKey(lattigo_genBootstrappingKey2(keygen.getRawHandle(), params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle(), relinKey.getRawHandle(), rotKeys.getRawHandle()));
+    }
+
+    SwitchingKey genSwkDenseToSparse(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk){
+      return SwitchingKey(lattigo_genSwkDenseToSparse(params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle()));
+    }
+
+    SwitchingKey genSwkSparseToDense(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk){
+      return SwitchingKey(lattigo_genSwkSparseToDense(params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle()));
     }
 
     SwitchingKey newSwitchingKey(const Parameters &params, uint64_t levelQ, uint64_t levelP) {

--- a/src/latticpp/ckks/keygen.cpp
+++ b/src/latticpp/ckks/keygen.cpp
@@ -98,6 +98,10 @@ namespace latticpp {
         return RelinearizationKey(lattigo_genRelinearizationKey(keygen.getRawHandle(), sk.getRawHandle()));
     }
 
+    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, vector<int> shifts) {
+      return genRotationKeysForRotations(keygen, sk, shifts, false);
+    }
+
     RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, vector<int> shifts, int includeConjugate) {
         // convert from variable-sized int to fixed-size SIGNED int64_t
         vector<int64_t> fixed_width_shifts(shifts.size());
@@ -139,8 +143,13 @@ namespace latticpp {
                                          rotKeys.getRawHandle());
     }
 
-    BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys) {
-        return BootstrappingKey(lattigo_genBootstrappingKey(keygen.getRawHandle(), params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle(), relinKey.getRawHandle(), rotKeys.getRawHandle()));
+    // DEPRACATED
+    BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey & /*relinKey*/, const RotationKeys &/*rotKeys*/) {
+        return genBootstrappingKey(keygen, params, bootParams, sk);
+    }
+
+  BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk) {
+        return BootstrappingKey(lattigo_genBootstrappingKey(keygen.getRawHandle(), params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle()));
     }
 
     BootstrappingKey genBootstrappingKey(const RelinearizationKey &relinKey, const RotationKeys &rotKeys, const SwitchingKey swkDtS, const SwitchingKey swkStD) {

--- a/src/latticpp/ckks/keygen.cpp
+++ b/src/latticpp/ckks/keygen.cpp
@@ -143,16 +143,13 @@ namespace latticpp {
         return BootstrappingKey(lattigo_genBootstrappingKey(keygen.getRawHandle(), params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle(), relinKey.getRawHandle(), rotKeys.getRawHandle()));
     }
 
-    BootstrappingKey genBootstrappingKey2(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys) {
-        return BootstrappingKey(lattigo_genBootstrappingKey2(keygen.getRawHandle(), params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle(), relinKey.getRawHandle(), rotKeys.getRawHandle()));
+    BootstrappingKey genBootstrappingKey(const RelinearizationKey &relinKey, const RotationKeys &rotKeys, const SwitchingKey swkDtS, const SwitchingKey swkStD) {
+        return BootstrappingKey(lattigo_genBootstrappingKeyByParams(relinKey.getRawHandle(), rotKeys.getRawHandle(),swkDtS.getRawHandle() , swkStD.getRawHandle()));
     }
 
-    SwitchingKey genSwkDenseToSparse(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk){
-      return SwitchingKey(lattigo_genSwkDenseToSparse(params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle()));
-    }
-
-    SwitchingKey genSwkSparseToDense(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk){
-      return SwitchingKey(lattigo_genSwkSparseToDense(params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle()));
+    BootstrapSwkPairHandle genBootstrapSwkPair(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk){
+      Lattigo_BootstrapSwkPairHandle btsSwkPairHandle = lattigo_genBootstrapSwkPair(params.getRawHandle(), bootParams.getRawHandle(), sk.getRawHandle());
+      return BootstrapSwkPairHandle{ SwitchingKey(btsSwkPairHandle.swkStD), SwitchingKey(btsSwkPairHandle.swkDtS) };
     }
 
     SwitchingKey newSwitchingKey(const Parameters &params, uint64_t levelQ, uint64_t levelP) {

--- a/src/latticpp/ckks/keygen.h
+++ b/src/latticpp/ckks/keygen.h
@@ -66,6 +66,8 @@ namespace latticpp {
 
     RelinearizationKey genRelinKey(const KeyGenerator &keygen, const SecretKey &sk);
 
+    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, std::vector<int> shifts);
+
     RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, std::vector<int> shifts, int includeConjugate);
 
     EvaluationKey makeEvaluationKey(const RelinearizationKey &relinKey);
@@ -80,7 +82,10 @@ namespace latticpp {
     void setRotKeysForEvaluationKey(const EvaluationKey &evalKey,
                                     const RotationKeys &rotKeys);
 
+    // DEPRACATED
     BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
+
+    BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk);
 
     BootstrappingKey genBootstrappingKey(const RelinearizationKey &relinKey, const RotationKeys &rotKeys, const SwitchingKey swkDtS, const SwitchingKey swkStD);
  

--- a/src/latticpp/ckks/keygen.h
+++ b/src/latticpp/ckks/keygen.h
@@ -66,9 +66,7 @@ namespace latticpp {
 
     RelinearizationKey genRelinKey(const KeyGenerator &keygen, const SecretKey &sk);
 
-    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, std::vector<int> shifts);
-
-    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, std::vector<int> shifts, int includeConjugate);
+    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, std::vector<int> shifts, int includeConjugate=0);
 
     EvaluationKey makeEvaluationKey(const RelinearizationKey &relinKey);
 
@@ -81,9 +79,6 @@ namespace latticpp {
 
     void setRotKeysForEvaluationKey(const EvaluationKey &evalKey,
                                     const RotationKeys &rotKeys);
-
-    // DEPRACATED: use genBootstrappingKey with the same list of parameters excluding RelinearizationKey, RotationKeys
-    BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
 
     BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk);
 

--- a/src/latticpp/ckks/keygen.h
+++ b/src/latticpp/ckks/keygen.h
@@ -82,7 +82,7 @@ namespace latticpp {
     void setRotKeysForEvaluationKey(const EvaluationKey &evalKey,
                                     const RotationKeys &rotKeys);
 
-    // DEPRACATED
+    // DEPRACATED: use genBootstrappingKey with the same list of parameters excluding RelinearizationKey, RotationKeys
     BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
 
     BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk);

--- a/src/latticpp/ckks/keygen.h
+++ b/src/latticpp/ckks/keygen.h
@@ -14,6 +14,11 @@ namespace latticpp {
         PublicKey pk;
     };
 
+    struct BootstrapSwkPairHandle {
+        SwitchingKey swkStD;
+        SwitchingKey swkDtS;
+    };
+
     KeyGenerator newKeyGenerator(const Parameters &params);
 
     SwitchingKey getSwitchingKey(const RotationKeys &rtks, uint64_t galEl);
@@ -77,11 +82,9 @@ namespace latticpp {
 
     BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
 
-    BootstrappingKey genBootstrappingKey2(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
-
-    SwitchingKey genSwkSparseToDense(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk);
-
-    SwitchingKey genSwkDenseToSparse(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk);
+    BootstrappingKey genBootstrappingKey(const RelinearizationKey &relinKey, const RotationKeys &rotKeys, const SwitchingKey swkDtS, const SwitchingKey swkStD);
+ 
+    BootstrapSwkPairHandle genBootstrapSwkPair(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk);
 
     PolyQP polyQP(const SecretKey &sk);
 

--- a/src/latticpp/ckks/keygen.h
+++ b/src/latticpp/ckks/keygen.h
@@ -61,7 +61,7 @@ namespace latticpp {
 
     RelinearizationKey genRelinKey(const KeyGenerator &keygen, const SecretKey &sk);
 
-    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, std::vector<int> shifts);
+    RotationKeys genRotationKeysForRotations(const KeyGenerator &keygen, const SecretKey &sk, std::vector<int> shifts, int includeConjugate);
 
     EvaluationKey makeEvaluationKey(const RelinearizationKey &relinKey);
 
@@ -76,6 +76,12 @@ namespace latticpp {
                                     const RotationKeys &rotKeys);
 
     BootstrappingKey genBootstrappingKey(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
+
+    BootstrappingKey genBootstrappingKey2(const KeyGenerator &keygen, const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk, const RelinearizationKey &relinKey, const RotationKeys &rotKeys);
+
+    SwitchingKey genSwkSparseToDense(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk);
+
+    SwitchingKey genSwkDenseToSparse(const Parameters &params, const BootstrappingParameters &bootParams, const SecretKey &sk);
 
     PolyQP polyQP(const SecretKey &sk);
 

--- a/src/latticpp/ckks/marshaler.cpp
+++ b/src/latticpp/ckks/marshaler.cpp
@@ -42,6 +42,11 @@ namespace latticpp {
         lattigo_marshalBinaryRotationKeys(rotKeys.getRawHandle(), &writeToStream, (void*)(&stream));
     }
 
+    void marshalBinarySwitchingKey(const SwitchingKey &switchingKey, std::ostream &stream){
+        lattigo_marshalBinarySwitchingKey(switchingKey.getRawHandle(), &writeToStream, (void*)(&stream));
+    }
+
+
     Ciphertext unmarshalBinaryCiphertext(istream &stream) {
         // Note: the next line is a well-known hard parsing problem for C++.
         // See https://stackoverflow.com/questions/4423361/constructing-a-vector-with-istream-iterators
@@ -81,4 +86,11 @@ namespace latticpp {
         vector<char> buffer(istreambuf_iterator<char>{stream}, {});
         return RotationKeys(lattigo_unmarshalBinaryRotationKeys(buffer.data(), buffer.size()));
     }
+
+    SwitchingKey unmarshalBinarySwitchingKey(istream &stream){
+        vector<char> buffer(istreambuf_iterator<char>{stream}, {});
+        return SwitchingKey(lattigo_unmarshalBinarySwitchingKey(buffer.data(), buffer.size()));
+    }
+
+    
 }  // namespace latticpp

--- a/src/latticpp/ckks/marshaler.h
+++ b/src/latticpp/ckks/marshaler.h
@@ -22,6 +22,9 @@ namespace latticpp {
 
     void marshalBinaryRotationKeys(const RotationKeys &rotKeys, std::ostream &stream);
 
+    void marshalBinarySwitchingKey(const SwitchingKey &switchingKey, std::ostream &stream);
+
+
     Ciphertext unmarshalBinaryCiphertext(std::istream &stream);
 
     Parameters unmarshalBinaryParameters(std::istream &stream);
@@ -35,4 +38,6 @@ namespace latticpp {
     RelinearizationKey unmarshalBinaryRelinearizationKey(std::istream &stream);
 
     RotationKeys unmarshalBinaryRotationKeys(std::istream &stream);
+
+    SwitchingKey unmarshalBinarySwitchingKey(std::istream &stream);
 }  // namespace latticpp


### PR DESCRIPTION
*Issue #22  

*Description of changes:*
This PR enable generating bootstrapping keys at the server side. Current API, requires the secret key which is not available in the server side. The new implementation require the generation of bootstrapping switching key pair and their marshaling.

1) Add support for un/marshal SwitchingKey 
2) Generate bootstrapping keys without secret key based on Lattigo v4.1.0 implementation https://github.com/tuneinsight/lattigo/blob/adf762375670e412bab261cd7ffff9ca03777ad5/ckks/bootstrapping/bootstrapper.go#L78
3) Enable generating conjugate rotation. Lattigo original API already supports this feature but the C++ wrapper used to call it with fixed "false" value. This is useful for generating bootstrapping keys manually.
4) Deprecated a function that accept unused parameters and fix bootstrapping example to use the fixed function

All the C++ wrapper examples are running successfully with this PR changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
